### PR TITLE
Fix a mistake for 5.2 chapter

### DIFF
--- a/5.2.md
+++ b/5.2.md
@@ -127,7 +127,7 @@ public class ExampleTweaker implements ITweaker {
             try {
                 File file = new File(location.toURI());
                 if (file.isFile()) {
-                    CoreModManager.getIgnoredMods().remove(file.getName());
+                    CoreModManager.getReparseableCoremods().remove(file.getName());
                 }
             } catch (URISyntaxException e) {
                 e.printStackTrace();


### PR DESCRIPTION
I am writing an example about how to use Mixin in Forge modding and I found a mistake in 5.2 chapter. If you are interested in why, you could see my [example](https://github.com/Mouse0w0/forge-mixin-example).